### PR TITLE
Added no prompt versions of cscope calls

### DIFF
--- a/helm-cscope.el
+++ b/helm-cscope.el
@@ -204,7 +204,7 @@
 
 ;;;###autoload
 (defun helm-cscope-find-global-definition-no-prompt()
-  "Locate a symbol in source code [no user prompting]."
+  "Find a symbol's global definition [no user prompting]."
   (interactive)
   (let ((symbol (cscope-extract-symbol-at-cursor nil nil)))
     (helm-cscope--find-common "-1" symbol)))

--- a/helm-cscope.el
+++ b/helm-cscope.el
@@ -21,6 +21,9 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+;;; Contributors:
+;; Sanjeev Sivasankaran <kalasalatemp at gmail.com> in 2019 added no-prompt versions.
+
 ;;; Commentary:
 
 ;; `helm-cscope.el' is a `helm' interface for xcscope.el.
@@ -185,12 +188,26 @@
   (helm-cscope--find-common "-0" symbol))
 
 ;;;###autoload
+(defun helm-cscope-find-this-symbol-no-prompt()
+  "Locate a symbol in source code [no user prompting]."
+  (interactive)
+  (let ((symbol (cscope-extract-symbol-at-cursor nil nil)))
+    (helm-cscope--find-common "-0" symbol)))
+
+;;;###autoload
 (defun helm-cscope-find-global-definition (symbol)
   "Find a symbol's global definition."
   (interactive
    (list (cscope-prompt-for-symbol
           "Find this global definition " nil nil t)))
   (helm-cscope--find-common "-1" symbol))
+
+;;;###autoload
+(defun helm-cscope-find-global-definition-no-prompt()
+  "Locate a symbol in source code [no user prompting]."
+  (interactive)
+  (let ((symbol (cscope-extract-symbol-at-cursor nil nil)))
+    (helm-cscope--find-common "-1" symbol)))
 
 ;;;###autoload
 (defun helm-cscope-find-called-function (symbol)
@@ -201,6 +218,13 @@
   (helm-cscope--find-common "-2" symbol))
 
 ;;;###autoload
+(defun helm-cscope-find-called-function-no-prompt ()
+  "Display functions called by a function [no user prompting]."
+  (interactive)
+  (let ((symbol (cscope-extract-symbol-at-cursor nil nil)))
+    (helm-cscope--find-common "-2" symbol)))
+
+;;;###autoload
 (defun helm-cscope-find-calling-this-function (symbol)
   "Display functions calling a function."
   (interactive
@@ -209,12 +233,26 @@
   (helm-cscope--find-common "-3" symbol))
 
 ;;;###autoload
+(defun helm-cscope-find-calling-this-function-no-prompt()
+  "Display functions calling a function [no user prompting]."
+  (interactive)
+  (let ((symbol (cscope-extract-symbol-at-cursor nil nil)))
+    (helm-cscope--find-common "-3" symbol)))
+
+;;;###autoload
 (defun helm-cscope-find-this-text-string (symbol)
   "Locate where a text string occurs."
   (interactive
    (list (cscope-prompt-for-symbol
           "Find this text string " nil t nil)))
   (helm-cscope--find-common "-4" symbol))
+
+;;;###autoload
+(defun helm-cscope-find-this-text-string-no-prompt()
+  "Locate where a text string occurs [no user prompting]."
+  (interactive)
+  (let ((symbol (cscope-extract-symbol-at-cursor nil nil)))
+    (helm-cscope--find-common "-4" symbol)))
 
 ;;;###autoload
 (defun helm-cscope-find-egrep-pattern (symbol)


### PR DESCRIPTION
Hello helm-cscope maintainer,

I have submitted no-prompt versions of cscope calls to the repository so users can point to a symbol
and make appropriate cscope calls. Can you please integrate ?