### PR TITLE
Automatically call select oper when only one result

### DIFF
--- a/helm-cscope.el
+++ b/helm-cscope.el
@@ -53,6 +53,9 @@
   "Face used to highlight line number in the *helm-cscope* buffer."
   :group 'helm-cscope)
 
+(defvar helm-cscope-execute-action-if-one nil
+  "Automatically perform action if result consists of only one row.")
+
 (defconst helm-cscope--parse-regexp
   "\\`\\([^ ]+\\) \\([^ ]+\\) \\([0-9]+\\) \\(.*\\)")
 
@@ -191,7 +194,8 @@
 (defun helm-cscope-find-this-symbol-no-prompt()
   "Locate a symbol in source code [no user prompting]."
   (interactive)
-  (let ((symbol (cscope-extract-symbol-at-cursor nil nil)))
+  (let ((symbol (cscope-extract-symbol-at-cursor nil nil))
+        (helm-execute-action-at-once-if-one helm-cscope-execute-action-if-one))
     (helm-cscope--find-common "-0" symbol)))
 
 ;;;###autoload
@@ -206,7 +210,8 @@
 (defun helm-cscope-find-global-definition-no-prompt()
   "Find a symbol's global definition [no user prompting]."
   (interactive)
-  (let ((symbol (cscope-extract-symbol-at-cursor nil nil)))
+  (let ((symbol (cscope-extract-symbol-at-cursor nil nil))
+        (helm-execute-action-at-once-if-one helm-cscope-execute-action-if-one))
     (helm-cscope--find-common "-1" symbol)))
 
 ;;;###autoload
@@ -221,7 +226,8 @@
 (defun helm-cscope-find-called-function-no-prompt ()
   "Display functions called by a function [no user prompting]."
   (interactive)
-  (let ((symbol (cscope-extract-symbol-at-cursor nil nil)))
+  (let ((symbol (cscope-extract-symbol-at-cursor nil nil))
+        (helm-execute-action-at-once-if-one helm-cscope-execute-action-if-one))
     (helm-cscope--find-common "-2" symbol)))
 
 ;;;###autoload
@@ -236,7 +242,8 @@
 (defun helm-cscope-find-calling-this-function-no-prompt()
   "Display functions calling a function [no user prompting]."
   (interactive)
-  (let ((symbol (cscope-extract-symbol-at-cursor nil nil)))
+  (let ((symbol (cscope-extract-symbol-at-cursor nil nil))
+        (helm-execute-action-at-once-if-one helm-cscope-execute-action-if-one))
     (helm-cscope--find-common "-3" symbol)))
 
 ;;;###autoload
@@ -251,7 +258,8 @@
 (defun helm-cscope-find-this-text-string-no-prompt()
   "Locate where a text string occurs [no user prompting]."
   (interactive)
-  (let ((symbol (cscope-extract-symbol-at-cursor nil nil)))
+  (let ((symbol (cscope-extract-symbol-at-cursor nil nil))
+        (helm-execute-action-at-once-if-one helm-cscope-execute-action-if-one))
     (helm-cscope--find-common "-4" symbol)))
 
 ;;;###autoload
@@ -276,7 +284,8 @@
 (defun helm-cscope-find-this-file-no-prompt ()
   "Locate a file [no user prompting]."
   (interactive)
-  (let ((symbol (cscope-extract-symbol-at-cursor nil nil)))
+  (let ((symbol (cscope-extract-symbol-at-cursor nil nil))
+        (helm-execute-action-at-once-if-one helm-cscope-execute-action-if-one))
     (helm-cscope--find-common "-7" symbol)))
 
 ;;;###autoload
@@ -291,7 +300,8 @@
 (defun helm-cscope-find-files-including-file-no-prompt ()
   "Locate all files #including a file [no user prompting]."
   (interactive)
-  (let ((symbol (cscope-extract-symbol-at-cursor nil nil)))
+  (let ((symbol (cscope-extract-symbol-at-cursor nil nil))
+        (helm-execute-action-at-once-if-one helm-cscope-execute-action-if-one))
   (helm-cscope--find-common "-8" symbol)))
 
 ;;;###autoload
@@ -306,7 +316,8 @@
 (defun helm-cscope-find-assignments-to-this-symbol-no-prompt ()
   "Locate assignments to a symbol in the source code[no user prompting]."
   (interactive)
-  (let ((symbol (cscope-extract-symbol-at-cursor nil nil)))
+  (let ((symbol (cscope-extract-symbol-at-cursor nil nil))
+        (helm-execute-action-at-once-if-one helm-cscope-execute-action-if-one))
   (helm-cscope--find-common "-9" symbol)))
 
 (defvar helm-cscope-mode-name " Helm cscope")


### PR DESCRIPTION
This change makes it possible to automatically jump to the destination if there is only one result in the result list. It is rather tedious to press return again if there is only one result.

- It adds a new variable to select if that behavior is wanted:
  helm-cscope-execute-action-if-one: default value is nil to maintain the current behavior

- The variable is only used for the no prompt functions.